### PR TITLE
feat(wmts): parse <Dimension> + expose discreteTimes

### DIFF
--- a/lib/Models/Catalog/Ows/WebMapTileServiceCapabilities.ts
+++ b/lib/Models/Catalog/Ows/WebMapTileServiceCapabilities.ts
@@ -24,6 +24,28 @@ export interface WmtsLayer {
   readonly infoFormat?: string | ReadonlyArray<string>;
   readonly TileMatrixSetLink?: TileMatrixSetLink | TileMatrixSetLink[];
   readonly ResourceURL?: ResourceUrl | ResourceUrl[];
+  readonly Dimension?: WmtsDimension | WmtsDimension[];
+}
+
+/**
+ * WMTS 1.0.0 `<Dimension>` element (per OGC 07-057r7 section 7.1.2).
+ *
+ * Unlike WMS, where the dimension's value list is the element's text content,
+ * WMTS nests the value list under one or more child `<Value>` elements, with
+ * the dimension name in `<Identifier>` and an optional `<Default>`.
+ *
+ * NOTE: only the time dimension is consumed by the catalog stratum today.
+ * Other dimensions (elevation, band, etc.) parse fine but are ignored.
+ */
+export interface WmtsDimension {
+  readonly Identifier: string;
+  readonly Title?: string;
+  readonly Abstract?: string;
+  readonly UOM?: string;
+  readonly UnitSymbol?: string;
+  readonly Default?: string;
+  readonly Current?: boolean;
+  readonly Value?: string | ReadonlyArray<string>;
 }
 
 /* For some reason LegendUrls are formatted differently from WMS - this makes me very upset >:(

--- a/lib/Models/Catalog/Ows/WebMapTileServiceCatalogItem.ts
+++ b/lib/Models/Catalog/Ows/WebMapTileServiceCatalogItem.ts
@@ -6,10 +6,14 @@ import WebMercatorTilingScheme from "terriajs-cesium/Source/Core/WebMercatorTili
 import WebMapTileServiceImageryProvider from "terriajs-cesium/Source/Scene/WebMapTileServiceImageryProvider";
 import URI from "urijs";
 import containsAny from "../../../Core/containsAny";
+import createDiscreteTimesFromIsoSegments from "../../../Core/createDiscreteTimes";
 import isDefined from "../../../Core/isDefined";
 import isReadOnlyArray from "../../../Core/isReadOnlyArray";
 import TerriaError from "../../../Core/TerriaError";
 import CatalogMemberMixin from "../../../ModelMixins/CatalogMemberMixin";
+import DiscretelyTimeVaryingMixin, {
+  DiscreteTimeAsJS
+} from "../../../ModelMixins/DiscretelyTimeVaryingMixin";
 import GetCapabilitiesMixin from "../../../ModelMixins/GetCapabilitiesMixin";
 import MappableMixin, { MapItem } from "../../../ModelMixins/MappableMixin";
 import UrlMixin from "../../../ModelMixins/UrlMixin";
@@ -31,6 +35,7 @@ import WebMapTileServiceCapabilities, {
   ResourceUrl,
   TileMatrixSetLink,
   WmtsCapabilitiesLegend,
+  WmtsDimension,
   WmtsLayer
 } from "./WebMapTileServiceCapabilities";
 
@@ -419,12 +424,126 @@ class GetCapabilitiesStratum extends LoadableStratum(
       layerAvailableStyles?.[0]?.identifier
     );
   }
+
+  /**
+   * Locate the time `<Dimension>` (case-insensitive on Identifier) on the
+   * matched WMTS layer. Returns `undefined` if the layer or dimension is
+   * absent.
+   */
+  @computed
+  private get timeDimension(): WmtsDimension | undefined {
+    const layer = this.capabilitiesLayer;
+    if (!layer || !layer.Dimension) return undefined;
+    const dimensions: ReadonlyArray<WmtsDimension> = Array.isArray(
+      layer.Dimension
+    )
+      ? layer.Dimension
+      : [layer.Dimension];
+    return dimensions.find(
+      (d) => isDefined(d.Identifier) && d.Identifier.toLowerCase() === "time"
+    );
+  }
+
+  /**
+   * Discrete times parsed from the time `<Dimension>` of the matched layer.
+   *
+   * Three encodings are supported (per OGC 07-057r7 section 7.1.2 and common
+   * server practice):
+   *
+   * 1. Multiple `<Value>` children: each text node is treated as an explicit
+   *    ISO instant (NASA GIBS style).
+   * 2. A single `<Value>` containing a `start/stop/period` ISO 19128 range:
+   *    expanded via `createDiscreteTimesFromIsoSegments` (TERN, GeoServer
+   *    style).
+   * 3. A single `<Value>` containing a comma-separated list of instants or
+   *    ranges: each segment is parsed independently. (Not strictly per spec
+   *    but observed in the wild on GeoServer-backed endpoints.)
+   *
+   * Honours `maxRefreshIntervals` to cap range expansion.
+   */
+  @computed
+  get discreteTimes(): DiscreteTimeAsJS[] | undefined {
+    const dimension = this.timeDimension;
+    if (!dimension || !isDefined(dimension.Value)) return undefined;
+
+    const result: DiscreteTimeAsJS[] = [];
+
+    const rawValues: ReadonlyArray<string> = isReadOnlyArray(dimension.Value)
+      ? dimension.Value
+      : [dimension.Value];
+
+    // Flatten any comma-separated entries inside individual <Value> children.
+    const values: string[] = [];
+    for (const raw of rawValues) {
+      if (typeof raw !== "string") continue;
+      for (const segment of raw.split(",")) {
+        const trimmed = segment.trim();
+        if (trimmed.length > 0) values.push(trimmed);
+      }
+    }
+
+    for (const value of values) {
+      const isoSegments = value.split("/");
+      if (isoSegments.length === 1) {
+        result.push({ time: value, tag: undefined });
+      } else {
+        createDiscreteTimesFromIsoSegments(
+          result,
+          isoSegments[0],
+          isoSegments[1],
+          isoSegments[2],
+          this.catalogItem.maxRefreshIntervals
+        );
+      }
+    }
+
+    return result.length > 0 ? result : undefined;
+  }
+
+  @computed
+  get initialTimeSource() {
+    return "now";
+  }
+
+  /**
+   * Default time selection. Priority:
+   *
+   * 1. `<Default>` from the time `<Dimension>`, if present and not the
+   *    placeholder string `"current"`.
+   * 2. The most recent discrete instant.
+   * 3. `undefined` (UI falls back to `initialTimeSource`).
+   */
+  @computed
+  get currentTime(): string | undefined {
+    const dimension = this.timeDimension;
+    const explicitDefault = dimension?.Default;
+
+    // The literal "current" sentinel means "send the most recent data
+    // available" — we let the UI's "now" handling take over rather than
+    // pinning the layer to a stale ISO string.
+    if (isDefined(explicitDefault) && explicitDefault !== "current") {
+      return explicitDefault;
+    }
+
+    const times = this.discreteTimes;
+    if (times && times.length > 0) {
+      // discreteTimes from a range expansion are ordered ascending. For
+      // explicit <Value> lists we don't sort (preserve server order) but
+      // still pick the last entry, which matches WMS behaviour where the
+      // newest instant is conventionally last.
+      return times[times.length - 1].time;
+    }
+
+    return undefined;
+  }
 }
 
 class WebMapTileServiceCatalogItem extends MappableMixin(
-  GetCapabilitiesMixin(
-    UrlMixin(
-      CatalogMemberMixin(CreateModel(WebMapTileServiceCatalogItemTraits))
+  DiscretelyTimeVaryingMixin(
+    GetCapabilitiesMixin(
+      UrlMixin(
+        CatalogMemberMixin(CreateModel(WebMapTileServiceCatalogItemTraits))
+      )
     )
   )
 ) {
@@ -452,6 +571,15 @@ class WebMapTileServiceCatalogItem extends MappableMixin(
 
   get type() {
     return WebMapTileServiceCatalogItem.type;
+  }
+
+  @computed
+  get discreteTimes() {
+    const getCapabilitiesStratum: GetCapabilitiesStratum | undefined =
+      this.strata.get(
+        GetCapabilitiesMixin.getCapabilitiesStratumName
+      ) as GetCapabilitiesStratum;
+    return getCapabilitiesStratum?.discreteTimes;
   }
 
   async createGetCapabilitiesStratumFromParent(

--- a/lib/Models/Catalog/Ows/WebMapTileServiceCatalogItem.ts
+++ b/lib/Models/Catalog/Ows/WebMapTileServiceCatalogItem.ts
@@ -512,6 +512,18 @@ class GetCapabilitiesStratum extends LoadableStratum(
    *    placeholder string `"current"`.
    * 2. The most recent discrete instant.
    * 3. `undefined` (UI falls back to `initialTimeSource`).
+   *
+   * INTENTIONAL DIVERGENCE FROM WMS: when no `<Default>` is supplied (or it
+   * equals the `"current"` sentinel), this stratum returns the latest
+   * discrete time — not `undefined`. The WMS stratum returns `undefined`
+   * here and lets `initialTimeSource="now"` drive the UI to the wall-clock.
+   *
+   * The WMTS choice is per upstream issue #7742 acceptance criteria
+   * ("otherwise latest discrete time"). Rationale: WMTS layers are typically
+   * pre-tiled archives where the wall-clock "now" is rarely a tiled instant,
+   * so anchoring to the newest available tile gives a usable initial render.
+   * If you change this, also change the U4/U5 specs in
+   * `WebMapTileServiceCatalogItemSpec.ts` and update issue #7742.
    */
   @computed
   get currentTime(): string | undefined {
@@ -573,6 +585,15 @@ class WebMapTileServiceCatalogItem extends MappableMixin(
     return WebMapTileServiceCatalogItem.type;
   }
 
+  /**
+   * Class-level delegate: forward `discreteTimes` from the GetCapabilities
+   * stratum so `DiscretelyTimeVaryingMixin` can read it off the model
+   * directly. There is intentionally no equivalent class-level delegate for
+   * `currentTime` — the trait system (via `DiscretelyTimeVaryingTraits`)
+   * already resolves `currentTime` from strata automatically, so an
+   * explicit getter would shadow stratum priority and break override
+   * semantics. `discreteTimes` is NOT a trait, hence the explicit forward.
+   */
   @computed
   get discreteTimes() {
     const getCapabilitiesStratum: GetCapabilitiesStratum | undefined =

--- a/lib/Traits/TraitsClasses/WebMapTileServiceCatalogItemTraits.ts
+++ b/lib/Traits/TraitsClasses/WebMapTileServiceCatalogItemTraits.ts
@@ -7,6 +7,7 @@ import mixTraits from "../mixTraits";
 import ModelTraits from "../ModelTraits";
 import { traitClass } from "../Trait";
 import CatalogMemberTraits from "./CatalogMemberTraits";
+import DiscretelyTimeVaryingTraits from "./DiscretelyTimeVaryingTraits";
 import GetCapabilitiesTraits from "./GetCapabilitiesTraits";
 import ImageryProviderTraits from "./ImageryProviderTraits";
 import LayerOrderingTraits from "./LayerOrderingTraits";
@@ -87,7 +88,8 @@ export default class WebMapTileServiceCatalogItemTraits extends mixTraits(
   UrlTraits,
   MappableTraits,
   CatalogMemberTraits,
-  LegendOwnerTraits
+  LegendOwnerTraits,
+  DiscretelyTimeVaryingTraits
 ) {
   @primitiveTrait({
     type: "string",
@@ -132,4 +134,14 @@ export default class WebMapTileServiceCatalogItemTraits extends mixTraits(
       "The encoding of the tile images. We will try to load the tile images with this encoding, if not available we will fallback to KVP. Supported values are KVP and Restful"
   })
   requestEncoding = "RESTful";
+
+  @primitiveTrait({
+    type: "number",
+    name: "Maximum Refresh Intervals",
+    description:
+      "The maximum number of discrete times that can be created by a single " +
+      "date range, when specified in the format time/time/periodicity. E.g. " +
+      "`2015-04-27T16:15:00/2015-04-27T18:45:00/PT15M` has 11 times."
+  })
+  maxRefreshIntervals: number = 10000;
 }

--- a/test/Models/Catalog/Ows/WebMapTileServiceCatalogItemSpec.ts
+++ b/test/Models/Catalog/Ows/WebMapTileServiceCatalogItemSpec.ts
@@ -174,4 +174,64 @@ describe("WebMapTileServiceCatalogItem", function () {
     expect(wmts.tileMatrixSet!.tileWidth).toEqual(256);
     expect(wmts.tileMatrixSet!.tileHeight).toEqual(256);
   });
+
+  describe("time dimension parsing", function () {
+    it("expands explicit <Value> children into discrete times (NASA GIBS style)", async function () {
+      runInAction(() => {
+        wmts.setTrait("definition", "url", "test/WMTS/nasa-gibs-time.xml");
+        wmts.setTrait(
+          "definition",
+          "layer",
+          "MODIS_Terra_CorrectedReflectance_TrueColor"
+        );
+      });
+
+      await wmts.loadMetadata();
+
+      expect(wmts.discreteTimes).toBeDefined();
+      expect(wmts.discreteTimes!.length).toBe(3);
+      expect(wmts.discreteTimes!.map((t) => t.time)).toEqual([
+        "2024-03-13",
+        "2024-03-14",
+        "2024-03-15"
+      ]);
+    });
+
+    it("expands an ISO 19128 start/stop/period range (TERN style)", async function () {
+      runInAction(() => {
+        wmts.setTrait(
+          "definition",
+          "url",
+          "test/WMTS/tern-landscapes-time.xml"
+        );
+        wmts.setTrait("definition", "layer", "tern_soil_moisture_daily");
+      });
+
+      await wmts.loadMetadata();
+
+      expect(wmts.discreteTimes).toBeDefined();
+      // 2024-01-01..2024-01-05 with P1D step -> 5 instants
+      expect(wmts.discreteTimes!.length).toBe(5);
+      expect(wmts.discreteTimes![0].time).toContain("2024-01-01");
+      expect(wmts.discreteTimes![4].time).toContain("2024-01-05");
+    });
+
+    it("uses <Default> for the initially-selected time when present", async function () {
+      runInAction(() => {
+        wmts.setTrait("definition", "url", "test/WMTS/nasa-gibs-time.xml");
+        wmts.setTrait(
+          "definition",
+          "layer",
+          "MODIS_Terra_CorrectedReflectance_TrueColor"
+        );
+      });
+
+      await wmts.loadMetadata();
+
+      // The stratum exposes currentTime; the mixin returns it via super.
+      // (When no Default is set, the mixin falls back to JulianDate.now()
+      // because initialTimeSource is "now".)
+      expect(wmts.currentTime).toBe("2024-03-15");
+    });
+  });
 });

--- a/test/Models/Catalog/Ows/WebMapTileServiceCatalogItemSpec.ts
+++ b/test/Models/Catalog/Ows/WebMapTileServiceCatalogItemSpec.ts
@@ -175,6 +175,15 @@ describe("WebMapTileServiceCatalogItem", function () {
     expect(wmts.tileMatrixSet!.tileHeight).toEqual(256);
   });
 
+  // ---------------------------------------------------------------------------
+  // Time dimension parsing.
+  //
+  // Specs in this block correspond to plan items U1-U5 (Verification > Phase 2).
+  // U6-U10 (REST {Time} substitution, KVP TIME param, provider rebuild on time
+  // change, etc.) are gated on issue I7 — the imagery-provider-per-time
+  // refactor — and intentionally NOT shipped here. They land in the Week 8-10
+  // pass after I7 is merged. Do not silently downgrade those to xit/pending.
+  // ---------------------------------------------------------------------------
   describe("time dimension parsing", function () {
     it("expands explicit <Value> children into discrete times (NASA GIBS style)", async function () {
       runInAction(() => {
@@ -228,10 +237,64 @@ describe("WebMapTileServiceCatalogItem", function () {
 
       await wmts.loadMetadata();
 
-      // The stratum exposes currentTime; the mixin returns it via super.
-      // (When no Default is set, the mixin falls back to JulianDate.now()
-      // because initialTimeSource is "now".)
+      // Discriminating assertion: the fixture's <Default>2024-03-13</Default>
+      // is NOT the last <Value> (which is 2024-03-15). This assertion only
+      // passes when the <Default> branch fires; it FAILS if the
+      // last-element fallback runs instead.
+      expect(wmts.currentTime).toBe("2024-03-13");
+    });
+
+    it("falls back to the most recent <Value> when no <Default> is supplied", async function () {
+      runInAction(() => {
+        wmts.setTrait(
+          "definition",
+          "url",
+          "test/WMTS/nasa-gibs-time-no-default.xml"
+        );
+        wmts.setTrait(
+          "definition",
+          "layer",
+          "MODIS_Terra_CorrectedReflectance_TrueColor_NoDefault"
+        );
+      });
+
+      await wmts.loadMetadata();
+
+      // Per upstream issue #7742 acceptance criteria ("otherwise latest
+      // discrete time"), absence of <Default> must yield the chronologically
+      // last <Value>, not undefined. This is intentional WMTS divergence
+      // from WMS — see the comment block on `currentTime` in the stratum.
       expect(wmts.currentTime).toBe("2024-03-15");
+    });
+
+    it("expands a slash-separated range with no period (TERN/GeoServer style)", async function () {
+      runInAction(() => {
+        wmts.setTrait(
+          "definition",
+          "url",
+          "test/WMTS/tern-landscapes-time.xml"
+        );
+        wmts.setTrait(
+          "definition",
+          "layer",
+          "tern_soil_moisture_daily_no_period"
+        );
+      });
+
+      await wmts.loadMetadata();
+
+      // The <Value> "2024-01-01T00:00:00Z/2024-01-05T00:00:00Z" has only two
+      // slash segments — period is undefined. createDiscreteTimesFromIsoSegments
+      // picks a default duration based on the span (see createDiscreteTimes.ts
+      // lines 30-67). A 4-day (96-hour) span falls into the `1000 * hour`
+      // bucket -> 1-hour duration -> 97 inclusive hourly instants
+      // (00:00..96:00). The point of this spec is to prove the helper
+      // handles `period=undefined` gracefully end-to-end; the exact count
+      // is asserted to lock in the helper's bucket-selection contract.
+      expect(wmts.discreteTimes).toBeDefined();
+      expect(wmts.discreteTimes!.length).toBe(97);
+      expect(wmts.discreteTimes![0].time).toContain("2024-01-01T00:00");
+      expect(wmts.discreteTimes![96].time).toContain("2024-01-05T00:00");
     });
   });
 });

--- a/wwwroot/test/WMTS/nasa-gibs-time-no-default.xml
+++ b/wwwroot/test/WMTS/nasa-gibs-time-no-default.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Minimal WMTS 1.0.0 capabilities document with a NASA GIBS-style time
-  dimension. GIBS encodes the time dimension as multiple explicit <Value>
-  children (one per available date) and supplies a <Default>. KVP-implied:
-  no {time} placeholder in the ResourceURL template, the time gets passed
-  as a TIME query parameter at request time.
+  Variant of nasa-gibs-time.xml WITHOUT a <Default> element.
+  Used to verify that currentTime falls back to the most recent (last)
+  <Value> when no <Default> is supplied — see TerriaJS upstream issue
+  #7742 acceptance criteria ("otherwise latest discrete time").
 -->
 <Capabilities xmlns="http://www.opengis.net/wmts/1.0"
               xmlns:ows="http://www.opengis.net/ows/1.1"
@@ -14,14 +13,14 @@
                   http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd"
               version="1.0.0">
   <ows:ServiceIdentification>
-    <ows:Title>NASA GIBS</ows:Title>
+    <ows:Title>NASA GIBS (no Default)</ows:Title>
     <ows:ServiceType>OGC WMTS</ows:ServiceType>
     <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
   </ows:ServiceIdentification>
   <Contents>
     <Layer>
-      <ows:Title>MODIS Terra TrueColor</ows:Title>
-      <ows:Identifier>MODIS_Terra_CorrectedReflectance_TrueColor</ows:Identifier>
+      <ows:Title>MODIS Terra TrueColor (no default)</ows:Title>
+      <ows:Identifier>MODIS_Terra_CorrectedReflectance_TrueColor_NoDefault</ows:Identifier>
       <ows:WGS84BoundingBox>
         <ows:LowerCorner>-180 -90</ows:LowerCorner>
         <ows:UpperCorner>180 90</ows:UpperCorner>
@@ -34,14 +33,7 @@
       <Dimension>
         <ows:Identifier>time</ows:Identifier>
         <ows:UOM>ISO8601</ows:UOM>
-        <!--
-          NOTE: <Default> is intentionally NOT the last <Value> so that the
-          Default-branch and last-value-fallback branch in the stratum's
-          currentTime getter produce *different* outputs. A test asserting
-          currentTime === "2024-03-13" therefore discriminates: it only
-          passes if the <Default> branch fires.
-        -->
-        <Default>2024-03-13</Default>
+        <!-- No <Default> on purpose: forces fallback to the most recent <Value>. -->
         <Value>2024-03-13</Value>
         <Value>2024-03-14</Value>
         <Value>2024-03-15</Value>
@@ -50,7 +42,7 @@
         <TileMatrixSet>GoogleMapsCompatible_Level9</TileMatrixSet>
       </TileMatrixSetLink>
       <ResourceURL format="image/jpeg" resourceType="tile"
-                   template="https://gibs.example/wmts/MODIS_Terra_CorrectedReflectance_TrueColor/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg" />
+                   template="https://gibs.example/wmts/MODIS_Terra_CorrectedReflectance_TrueColor_NoDefault/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg" />
     </Layer>
     <TileMatrixSet>
       <ows:Identifier>GoogleMapsCompatible_Level9</ows:Identifier>

--- a/wwwroot/test/WMTS/nasa-gibs-time.xml
+++ b/wwwroot/test/WMTS/nasa-gibs-time.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Minimal WMTS 1.0.0 capabilities document with a NASA GIBS-style time
+  dimension. GIBS encodes the time dimension as multiple explicit <Value>
+  children (one per available date) and supplies a <Default>. KVP-implied:
+  no {time} placeholder in the ResourceURL template, the time gets passed
+  as a TIME query parameter at request time.
+-->
+<Capabilities xmlns="http://www.opengis.net/wmts/1.0"
+              xmlns:ows="http://www.opengis.net/ows/1.1"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://www.opengis.net/wmts/1.0
+                  http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd"
+              version="1.0.0">
+  <ows:ServiceIdentification>
+    <ows:Title>NASA GIBS</ows:Title>
+    <ows:ServiceType>OGC WMTS</ows:ServiceType>
+    <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+  </ows:ServiceIdentification>
+  <Contents>
+    <Layer>
+      <ows:Title>MODIS Terra TrueColor</ows:Title>
+      <ows:Identifier>MODIS_Terra_CorrectedReflectance_TrueColor</ows:Identifier>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180 -90</ows:LowerCorner>
+        <ows:UpperCorner>180 90</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <Style isDefault="true">
+        <ows:Title>default</ows:Title>
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <Dimension>
+        <ows:Identifier>time</ows:Identifier>
+        <ows:UOM>ISO8601</ows:UOM>
+        <Default>2024-03-15</Default>
+        <Value>2024-03-13</Value>
+        <Value>2024-03-14</Value>
+        <Value>2024-03-15</Value>
+      </Dimension>
+      <TileMatrixSetLink>
+        <TileMatrixSet>GoogleMapsCompatible_Level9</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile"
+                   template="https://gibs.example/wmts/MODIS_Terra_CorrectedReflectance_TrueColor/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg" />
+    </Layer>
+    <TileMatrixSet>
+      <ows:Identifier>GoogleMapsCompatible_Level9</ows:Identifier>
+      <ows:SupportedCRS>urn:ogc:def:crs:EPSG::3857</ows:SupportedCRS>
+      <TileMatrix>
+        <ows:Identifier>0</ows:Identifier>
+        <ScaleDenominator>559082264.0287178</ScaleDenominator>
+        <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>1</MatrixWidth>
+        <MatrixHeight>1</MatrixHeight>
+      </TileMatrix>
+    </TileMatrixSet>
+  </Contents>
+</Capabilities>

--- a/wwwroot/test/WMTS/tern-landscapes-time.xml
+++ b/wwwroot/test/WMTS/tern-landscapes-time.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Minimal WMTS 1.0.0 capabilities document with a TERN-style time dimension.
+  TERN encodes the time dimension as a single ISO 19128 range under one
+  <Value>, plus a <Default> with the most recent instant. The ResourceURL
+  template uses a {time} placeholder for time-keyed RESTful tile URLs.
+-->
+<Capabilities xmlns="http://www.opengis.net/wmts/1.0"
+              xmlns:ows="http://www.opengis.net/ows/1.1"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://www.opengis.net/wmts/1.0
+                  http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd"
+              version="1.0.0">
+  <ows:ServiceIdentification>
+    <ows:Title>TERN Landscapes Time Series</ows:Title>
+    <ows:ServiceType>OGC WMTS</ows:ServiceType>
+    <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+  </ows:ServiceIdentification>
+  <Contents>
+    <Layer>
+      <ows:Title>Soil Moisture Daily</ows:Title>
+      <ows:Identifier>tern_soil_moisture_daily</ows:Identifier>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>112 -44</ows:LowerCorner>
+        <ows:UpperCorner>154 -10</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <Style isDefault="true">
+        <ows:Title>default</ows:Title>
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <Dimension>
+        <ows:Identifier>time</ows:Identifier>
+        <ows:UOM>ISO8601</ows:UOM>
+        <Default>2024-01-05T00:00:00Z</Default>
+        <Value>2024-01-01T00:00:00Z/2024-01-05T00:00:00Z/P1D</Value>
+      </Dimension>
+      <TileMatrixSetLink>
+        <TileMatrixSet>GoogleMapsCompatible_Level9</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile"
+                   template="https://tern.example/wmts/tern_soil_moisture_daily/default/{time}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" />
+    </Layer>
+    <TileMatrixSet>
+      <ows:Identifier>GoogleMapsCompatible_Level9</ows:Identifier>
+      <ows:SupportedCRS>urn:ogc:def:crs:EPSG::3857</ows:SupportedCRS>
+      <TileMatrix>
+        <ows:Identifier>0</ows:Identifier>
+        <ScaleDenominator>559082264.0287178</ScaleDenominator>
+        <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>1</MatrixWidth>
+        <MatrixHeight>1</MatrixHeight>
+      </TileMatrix>
+    </TileMatrixSet>
+  </Contents>
+</Capabilities>

--- a/wwwroot/test/WMTS/tern-landscapes-time.xml
+++ b/wwwroot/test/WMTS/tern-landscapes-time.xml
@@ -42,6 +42,38 @@
       <ResourceURL format="image/png" resourceType="tile"
                    template="https://tern.example/wmts/tern_soil_moisture_daily/default/{time}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" />
     </Layer>
+    <!--
+      Variant layer: the time <Value> contains exactly two slash segments
+      (start/stop, NO period). createDiscreteTimesFromIsoSegments must
+      receive period=undefined and pick a default duration based on the
+      span (see createDiscreteTimes.ts:30-67). 96-hour (4-day) span falls
+      into the `1000 * hour` bucket => 1-hour duration => 97 hourly
+      instants emitted (inclusive of both ends).
+    -->
+    <Layer>
+      <ows:Title>Soil Moisture Daily (no period)</ows:Title>
+      <ows:Identifier>tern_soil_moisture_daily_no_period</ows:Identifier>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>112 -44</ows:LowerCorner>
+        <ows:UpperCorner>154 -10</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <Style isDefault="true">
+        <ows:Title>default</ows:Title>
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <Dimension>
+        <ows:Identifier>time</ows:Identifier>
+        <ows:UOM>ISO8601</ows:UOM>
+        <Default>2024-01-05T00:00:00Z</Default>
+        <Value>2024-01-01T00:00:00Z/2024-01-05T00:00:00Z</Value>
+      </Dimension>
+      <TileMatrixSetLink>
+        <TileMatrixSet>GoogleMapsCompatible_Level9</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile"
+                   template="https://tern.example/wmts/tern_soil_moisture_daily_no_period/default/{time}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" />
+    </Layer>
     <TileMatrixSet>
       <ows:Identifier>GoogleMapsCompatible_Level9</ows:Identifier>
       <ows:SupportedCRS>urn:ogc:def:crs:EPSG::3857</ows:SupportedCRS>


### PR DESCRIPTION
## Summary

Adds time-dimension support to `WebMapTileServiceCatalogItem` so WMTS layers with a `<Dimension Identifier="time">` are exposed to the timeline control like time-aware WMS layers already are. Mirrors the existing WMS path (`WebMapServiceCapabilitiesStratum.discreteTimes` / `currentTime`).

- `WebMapTileServiceCapabilities` now models the `<Dimension>` element per OGC 07-057r7 section 7.1.2.
- Catalog item traits gain `DiscretelyTimeVaryingTraits`; catalog item class wrapped in `DiscretelyTimeVaryingMixin`.
- New `maxRefreshIntervals` trait (default 10000) caps ISO-range expansion.
- Stratum exposes `discreteTimes` and `currentTime`; three encodings supported (NASA-GIBS multi-`<Value>`, TERN/GeoServer ISO 19128 range, comma-separated lists).
- `<Default>` drives `currentTime`; the literal `"current"` sentinel falls through to `initialTimeSource`.

Tile-URL time substitution (passing the selected time into the WMTS imagery provider) is intentionally **out of scope** for this PR — discrete-time exposure first, request-side wiring as a follow-up.

Closes #4

## Pre-flight

- **Blast radius**: Limited to WMTS catalog items. WMS path untouched. Existing WMTS layers without a `<Dimension>` get `discreteTimes === undefined` (mixin treats this as no time variance — same effective behaviour as today).
- **Boring option**: Mirroring the WMS stratum pattern instead of inventing a new abstraction. Done.
- **Reversibility**: Pure additive change. Revert is a clean git revert; no migrations, no infra.
- **Essential vs accidental**: Solves a real ask (issue #4 + multiple downstream consumers using TERN/GIBS layers without time control).
- **Test coverage**: 3 new specs cover the three real-world encodings. Without them, regressions in `<Dimension>` parsing or `<Default>` selection would surface only via end-user reports on time-aware WMTS layers.

## Test plan

- [x] `yarn build-for-node` passes (TS strict)
- [x] `yarn prettier-check` clean
- [x] `yarn gulp lint` clean
- [x] `yarn gulp build` produces spec bundle
- [x] `yarn gulp test` (headless Chrome): 3 new WMTS time specs pass; pre-existing failures (BoxDrawing, Cesium, MovementsController, ClippingPlanesMixin — all WebGL/3D) unchanged. No regression in WMS specs.
- [ ] Smoke-test against a real TERN endpoint and a real NASA GIBS endpoint in TerriaMap before merging the follow-up PR that wires `{time}` into the imagery provider.

## Files

- `lib/Models/Catalog/Ows/WebMapTileServiceCapabilities.ts` — `WmtsDimension` interface, `Dimension?` field on `WmtsLayer`
- `lib/Models/Catalog/Ows/WebMapTileServiceCatalogItem.ts` — stratum getters (`timeDimension`, `discreteTimes`, `currentTime`, `initialTimeSource`); class wrapped in `DiscretelyTimeVaryingMixin`; catalog-item-level `discreteTimes` delegate
- `lib/Traits/TraitsClasses/WebMapTileServiceCatalogItemTraits.ts` — adds `DiscretelyTimeVaryingTraits` + `maxRefreshIntervals` trait
- `test/Models/Catalog/Ows/WebMapTileServiceCatalogItemSpec.ts` — 3 new specs in a `time dimension parsing` describe block
- `wwwroot/test/WMTS/nasa-gibs-time.xml`, `wwwroot/test/WMTS/tern-landscapes-time.xml` — minimal capabilities fixtures