### PR TITLE
feat(wmts): time.values trait override (Closes #14)

### DIFF
--- a/lib/Models/Catalog/Ows/WebMapTileServiceCatalogItem.ts
+++ b/lib/Models/Catalog/Ows/WebMapTileServiceCatalogItem.ts
@@ -32,6 +32,7 @@ import createStratumInstance from "../../Definition/createStratumInstance";
 import LoadableStratum from "../../Definition/LoadableStratum";
 import { BaseModel, ModelConstructorParameters } from "../../Definition/Model";
 import StratumFromTraits from "../../Definition/StratumFromTraits";
+import StratumOrder from "../../Definition/StratumOrder";
 import proxyCatalogItemUrl from "../proxyCatalogItemUrl";
 import { ServiceProvider } from "./OwsInterfaces";
 import WebMapTileServiceCapabilities, {
@@ -554,6 +555,102 @@ class GetCapabilitiesStratum extends LoadableStratum(
   }
 }
 
+/**
+ * Stratum that translates the user-supplied `time` trait (an explicit time
+ * dimension declaration in catalog JSON) into `discreteTimes` and
+ * `currentTime` values.
+ *
+ * Registered at HIGHER priority than `GetCapabilitiesStratum`, so when the
+ * user declares `time` in catalog JSON, the override values take precedence
+ * over whatever (if anything) the WMTS server advertises in `<Dimension>`.
+ *
+ * When `time` is unset, this stratum returns `undefined` for everything,
+ * letting `GetCapabilitiesStratum` provide values via the regular
+ * trait/stratum priority cascade — preserving existing behaviour.
+ *
+ * Required because GeoServer's GeoWebCache does not advertise `<Dimension>`
+ * in GetCapabilities even when the underlying layer has a configured time
+ * dimension. See issue #14.
+ */
+class TimeOverrideStratum extends LoadableStratum(
+  WebMapTileServiceCatalogItemTraits
+) {
+  static stratumName = "wmts-time-override";
+
+  constructor(readonly catalogItem: WebMapTileServiceCatalogItem) {
+    super();
+    makeObservable(this);
+  }
+
+  duplicateLoadableStratum(model: BaseModel): this {
+    return new TimeOverrideStratum(
+      model as WebMapTileServiceCatalogItem
+    ) as this;
+  }
+
+  /**
+   * Discrete times derived from the `time` trait. Returns `undefined` (and
+   * thereby falls through to GetCapabilitiesStratum) when the trait is not
+   * configured to produce a time set:
+   *   - `time.values` (preferred): used directly, sorted ascending.
+   *   - `time.start` + `time.stop` + `time.period`: expanded via
+   *     `createDiscreteTimesFromIsoSegments` (honours `maxRefreshIntervals`).
+   *   - Anything else (no `time`, only `defaultValue`, partial range): the
+   *     stratum has no times to provide here; GetCapabilities still runs
+   *     for `discreteTimes`. `currentTime` may still resolve from
+   *     `defaultValue` below.
+   */
+  @computed
+  get discreteTimes(): DiscreteTimeAsJS[] | undefined {
+    const t = this.catalogItem.time;
+    if (!t) return undefined;
+
+    if (t.values && t.values.length > 0) {
+      return [...t.values].sort().map((time) => ({ time, tag: undefined }));
+    }
+
+    if (isDefined(t.start) && isDefined(t.stop) && isDefined(t.period)) {
+      const result: DiscreteTimeAsJS[] = [];
+      createDiscreteTimesFromIsoSegments(
+        result,
+        t.start,
+        t.stop,
+        t.period,
+        this.catalogItem.maxRefreshIntervals
+      );
+      return result.length > 0 ? result : undefined;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Initial `currentTime` selection. Priority:
+   *   1. `time.defaultValue` if set.
+   *   2. The most recent value in `discreteTimes` (matches the
+   *      GetCapabilitiesStratum fallback contract).
+   *   3. `undefined` — falls through to GetCapabilitiesStratum / UI default.
+   */
+  @computed
+  get currentTime(): string | undefined {
+    const t = this.catalogItem.time;
+    if (!t) return undefined;
+
+    if (isDefined(t.defaultValue)) return t.defaultValue;
+
+    const dt = this.discreteTimes;
+    if (dt && dt.length > 0) return dt[dt.length - 1].time;
+
+    return undefined;
+  }
+}
+
+// Register `TimeOverrideStratum` AFTER the GetCapabilities stratum so it
+// receives a higher priority — the `time` trait override wins over whatever
+// the WMTS server advertises (or fails to advertise) in <Dimension>.
+// `getCapabilities` is registered when `GetCapabilitiesMixin` loads above.
+StratumOrder.addLoadStratum(TimeOverrideStratum.stratumName);
+
 class WebMapTileServiceCatalogItem extends MappableMixin(
   DiscretelyTimeVaryingMixin(
     GetCapabilitiesMixin(
@@ -580,9 +677,21 @@ class WebMapTileServiceCatalogItem extends MappableMixin(
 
   static readonly type = "wmts";
 
+  static readonly TimeOverrideStratumName = TimeOverrideStratum.stratumName;
+
   constructor(...args: ModelConstructorParameters) {
     super(...args);
     makeObservable(this);
+    // Register the override stratum unconditionally. When the `time` trait
+    // is unset its computed properties return `undefined`, so the priority
+    // cascade falls through to `GetCapabilitiesStratum` and existing
+    // behaviour is preserved. When `time` is set, this stratum's higher
+    // priority means its `currentTime` wins, and the class-level
+    // `discreteTimes` getter consults this stratum first.
+    this.strata.set(
+      TimeOverrideStratum.stratumName,
+      new TimeOverrideStratum(this)
+    );
   }
 
   get type() {
@@ -590,16 +699,28 @@ class WebMapTileServiceCatalogItem extends MappableMixin(
   }
 
   /**
-   * Class-level delegate: forward `discreteTimes` from the GetCapabilities
-   * stratum so `DiscretelyTimeVaryingMixin` can read it off the model
-   * directly. There is intentionally no equivalent class-level delegate for
+   * Class-level delegate: forward `discreteTimes` from the strata so
+   * `DiscretelyTimeVaryingMixin` can read it off the model directly.
+   * There is intentionally no equivalent class-level delegate for
    * `currentTime` — the trait system (via `DiscretelyTimeVaryingTraits`)
    * already resolves `currentTime` from strata automatically, so an
    * explicit getter would shadow stratum priority and break override
    * semantics. `discreteTimes` is NOT a trait, hence the explicit forward.
+   *
+   * Priority: `TimeOverrideStratum` (catalog-JSON `time` trait) wins over
+   * `GetCapabilitiesStratum`. This mirrors the trait-stratum priority used
+   * for `currentTime`. When the override stratum has nothing to say (no
+   * `time` trait or only `defaultValue` set), it returns `undefined` and
+   * we fall through to GetCapabilities — preserving existing behaviour.
    */
   @computed
   get discreteTimes() {
+    const overrideStratum: TimeOverrideStratum | undefined = this.strata.get(
+      TimeOverrideStratum.stratumName
+    ) as TimeOverrideStratum;
+    const overrideTimes = overrideStratum?.discreteTimes;
+    if (overrideTimes !== undefined) return overrideTimes;
+
     const getCapabilitiesStratum: GetCapabilitiesStratum | undefined =
       this.strata.get(
         GetCapabilitiesMixin.getCapabilitiesStratumName

--- a/lib/Traits/TraitsClasses/WebMapTileServiceCatalogItemTraits.ts
+++ b/lib/Traits/TraitsClasses/WebMapTileServiceCatalogItemTraits.ts
@@ -2,6 +2,7 @@ import { JsonObject } from "../../Core/Json";
 import anyTrait from "../Decorators/anyTrait";
 import objectArrayTrait from "../Decorators/objectArrayTrait";
 import objectTrait from "../Decorators/objectTrait";
+import primitiveArrayTrait from "../Decorators/primitiveArrayTrait";
 import primitiveTrait from "../Decorators/primitiveTrait";
 import mixTraits from "../mixTraits";
 import ModelTraits from "../ModelTraits";
@@ -51,6 +52,66 @@ export class WebMapTileServiceAvailableStyleTraits extends ModelTraits {
     description: "True if this Style is default; otherwise, false."
   })
   isDefault: boolean = false;
+}
+
+/**
+ * Explicit time-dimension override.
+ *
+ * Used when a WMTS server does not advertise a `<Dimension>` element in its
+ * GetCapabilities response (e.g., GeoServer's GeoWebCache, which strips
+ * Dimensions even when the underlying layer has time metadata configured).
+ * Lets catalog JSON declare the discrete time set, an ISO range, and/or a
+ * default selection without round-tripping through GetCapabilities.
+ *
+ * Resolution order in `TimeOverrideStratum`:
+ *   1. `values` (explicit list) — sorted ascending and used as-is.
+ *   2. `start` + `stop` + `period` — expanded via
+ *      `createDiscreteTimesFromIsoSegments` (honours `maxRefreshIntervals`).
+ *   3. Both absent — stratum returns `undefined` for `discreteTimes` and
+ *      falls through to `GetCapabilitiesStratum`, preserving prior behaviour.
+ *
+ * `defaultValue` selects the initial `currentTime`; absent it, the most
+ * recent discrete instant is selected (matches the GetCapabilities path).
+ */
+export class WebMapTileServiceTimeTraits extends ModelTraits {
+  @primitiveArrayTrait({
+    type: "string",
+    name: "Values",
+    description:
+      "Explicit list of ISO 8601 timestamps. Used directly as the discrete time set when present."
+  })
+  values?: string[];
+
+  @primitiveTrait({
+    type: "string",
+    name: "Start",
+    description:
+      "ISO 8601 range start. Use together with `stop` and `period` to declare a regular interval that will be expanded via `createDiscreteTimesFromIsoSegments`."
+  })
+  start?: string;
+
+  @primitiveTrait({
+    type: "string",
+    name: "Stop",
+    description: "ISO 8601 range stop. Use together with `start` and `period`."
+  })
+  stop?: string;
+
+  @primitiveTrait({
+    type: "string",
+    name: "Period",
+    description:
+      "ISO 8601 period (e.g., `P1D`, `PT1H`). Use together with `start` and `stop`."
+  })
+  period?: string;
+
+  @primitiveTrait({
+    type: "string",
+    name: "Default Value",
+    description:
+      "ISO 8601 timestamp to select initially. Falls back to the most recent discrete time when omitted."
+  })
+  defaultValue?: string;
 }
 
 export class WebMapTileServiceAvailableLayerStylesTraits extends ModelTraits {
@@ -144,4 +205,12 @@ export default class WebMapTileServiceCatalogItemTraits extends mixTraits(
       "`2015-04-27T16:15:00/2015-04-27T18:45:00/PT15M` has 11 times."
   })
   maxRefreshIntervals: number = 10000;
+
+  @objectTrait({
+    type: WebMapTileServiceTimeTraits,
+    name: "Time",
+    description:
+      "Explicit time-dimension configuration. Used when the WMTS server does not advertise `<Dimension>` in GetCapabilities (e.g., GeoServer GeoWebCache). When set, this overrides any time dimension parsed from GetCapabilities. When unset, time handling falls through to GetCapabilities (existing behaviour)."
+  })
+  time?: WebMapTileServiceTimeTraits;
 }

--- a/test/Models/Catalog/Ows/WebMapTileServiceCatalogItemSpec.ts
+++ b/test/Models/Catalog/Ows/WebMapTileServiceCatalogItemSpec.ts
@@ -2,7 +2,10 @@ import i18next from "i18next";
 import { autorun, runInAction } from "mobx";
 import { ImageryParts } from "../../../../lib/ModelMixins/MappableMixin";
 import WebMapTileServiceCatalogItem from "../../../../lib/Models/Catalog/Ows/WebMapTileServiceCatalogItem";
+import CommonStrata from "../../../../lib/Models/Definition/CommonStrata";
+import createStratumInstance from "../../../../lib/Models/Definition/createStratumInstance";
 import Terria from "../../../../lib/Models/Terria";
+import { WebMapTileServiceTimeTraits } from "../../../../lib/Traits/TraitsClasses/WebMapTileServiceCatalogItemTraits";
 
 describe("WebMapTileServiceCatalogItem", function () {
   let terria: Terria;
@@ -297,6 +300,127 @@ describe("WebMapTileServiceCatalogItem", function () {
       expect(wmts.discreteTimes!.length).toBe(97);
       expect(wmts.discreteTimes![0].time).toContain("2024-01-01T00:00");
       expect(wmts.discreteTimes![96].time).toContain("2024-01-05T00:00");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Explicit `time` trait override (issue #14).
+  //
+  // GeoServer's GeoWebCache does NOT advertise <Dimension> in GetCapabilities
+  // even when the underlying layer has time metadata. Catalog JSON authors
+  // must be able to declare the time set explicitly. The override stratum
+  // (TimeOverrideStratum) translates the `time` trait into discreteTimes /
+  // currentTime at higher priority than GetCapabilitiesStratum. When unset,
+  // the stratum returns undefined for everything and existing GetCapabilities-
+  // driven behaviour is preserved (regression spec below).
+  // ---------------------------------------------------------------------------
+  describe("explicit time override (issue #14)", function () {
+    it("uses time.values verbatim as discreteTimes, sorted ascending", function () {
+      // Path 1: explicit `values` list. We deliberately supply them out of
+      // order to lock in the documented contract that the stratum sorts
+      // ascending — UI timeline scrubbing relies on monotonically-increasing
+      // discrete times.
+      runInAction(() => {
+        wmts.setTrait(
+          CommonStrata.user,
+          "time",
+          createStratumInstance(WebMapTileServiceTimeTraits, {
+            values: [
+              "2024-01-03T00:00:00Z",
+              "2024-01-01T00:00:00Z",
+              "2024-01-02T00:00:00Z"
+            ]
+          })
+        );
+      });
+
+      // No GetCapabilities load is performed — the override stratum produces
+      // discreteTimes synchronously off the trait.
+      expect(wmts.discreteTimes).toBeDefined();
+      expect(wmts.discreteTimes!.length).toBe(3);
+      expect(wmts.discreteTimes![0].time).toBe("2024-01-01T00:00:00Z");
+      expect(wmts.discreteTimes![1].time).toBe("2024-01-02T00:00:00Z");
+      expect(wmts.discreteTimes![2].time).toBe("2024-01-03T00:00:00Z");
+    });
+
+    it("expands time.start/stop/period via createDiscreteTimesFromIsoSegments", function () {
+      // Path 2: ISO range. Mirrors the GetCapabilities range path
+      // (createDiscreteTimesFromIsoSegments) but driven from catalog JSON.
+      // P1D over 4 days = 5 inclusive instants (Jan 1, 2, 3, 4, 5).
+      runInAction(() => {
+        wmts.setTrait(
+          CommonStrata.user,
+          "time",
+          createStratumInstance(WebMapTileServiceTimeTraits, {
+            start: "2024-01-01T00:00:00Z",
+            stop: "2024-01-05T00:00:00Z",
+            period: "P1D"
+          })
+        );
+      });
+
+      expect(wmts.discreteTimes).toBeDefined();
+      expect(wmts.discreteTimes!.length).toBe(5);
+      expect(wmts.discreteTimes![0].time).toContain("2024-01-01");
+      expect(wmts.discreteTimes![4].time).toContain("2024-01-05");
+    });
+
+    it("selects time.defaultValue as currentTime when set", function () {
+      // currentTime priority: explicit defaultValue > most-recent discrete
+      // time > undefined. The most-recent value here is 2024-01-03 — asserting
+      // currentTime resolves to 2024-01-02 proves defaultValue takes precedence
+      // over the recency fallback.
+      runInAction(() => {
+        wmts.setTrait(
+          CommonStrata.user,
+          "time",
+          createStratumInstance(WebMapTileServiceTimeTraits, {
+            values: [
+              "2024-01-01T00:00:00Z",
+              "2024-01-02T00:00:00Z",
+              "2024-01-03T00:00:00Z"
+            ],
+            defaultValue: "2024-01-02T00:00:00Z"
+          })
+        );
+      });
+
+      expect(wmts.currentTime).toBe("2024-01-02T00:00:00Z");
+    });
+
+    it("falls through to GetCapabilities when the time trait is absent (regression)", async function () {
+      // Regression: with no `time` trait set, the override stratum's getters
+      // return undefined and GetCapabilitiesStratum drives discreteTimes /
+      // currentTime — i.e., existing behaviour is preserved. This is the
+      // critical "do no harm" assertion: if this spec fails, every existing
+      // WMTS catalog item with a server-advertised <Dimension> is broken.
+      runInAction(() => {
+        wmts.setTrait(
+          "definition",
+          "url",
+          "test/WMTS/tern-landscapes-time.xml"
+        );
+        wmts.setTrait("definition", "layer", "tern_soil_moisture_daily");
+      });
+
+      await wmts.loadMetadata();
+
+      // The TERN fixture advertises a daily P1D range over 5 days
+      // (2024-01-01..2024-01-05) — same fixture used by the GetCapabilities
+      // range spec above. 5 discrete times must come through unchanged.
+      // Note: TerriaJS object traits always materialize a wrapper model for
+      // property access — `wmts.time` is not `undefined` even when no stratum
+      // has set values. The meaningful regression check is on the unset inner
+      // fields plus the discreteTimes pass-through from GetCapabilities.
+      expect(wmts.time?.values).toBeUndefined();
+      expect(wmts.time?.start).toBeUndefined();
+      expect(wmts.time?.stop).toBeUndefined();
+      expect(wmts.time?.period).toBeUndefined();
+      expect(wmts.time?.defaultValue).toBeUndefined();
+      expect(wmts.discreteTimes).toBeDefined();
+      expect(wmts.discreteTimes!.length).toBe(5);
+      expect(wmts.discreteTimes![0].time).toContain("2024-01-01");
+      expect(wmts.discreteTimes![4].time).toContain("2024-01-05");
     });
   });
 


### PR DESCRIPTION
## Summary

Adds an explicit `time` trait + `TimeOverrideStratum` so catalog JSON can declare the WMTS time dimension when the server's GetCapabilities response does not advertise a `<Dimension>` element. Closes nextavllc/terriajs#14.

## Why

GeoServer's GeoWebCache — the layer in front of GeoServer that serves WMTS in our production stack — does **not** propagate `<Dimension>` into its WMTS GetCapabilities, even when the underlying layer has time metadata configured. This is a long-standing GWC behaviour: capability docs come from the cached WMTS skeleton, not the live GeoServer. Result: terriajs sees no time dimension, the timeline UI never appears, and our methaneview catalog cannot scrub through Sentinel-2 acquisitions.

We previously tried **Path Z'** on methaneview-platform: monkey-patch the GetCapabilities response client-side after the HTTP fetch but before terriajs parses it. That failed — terriajs consumes capability XML inside `WebMapTileServiceCapabilities.fromUrl` synchronously, with no extension hook we can wedge into without forking the parser. See methaneview Path Z' attempt notes.

This PR is **Path X**: declare the time set in catalog JSON instead. Server-agnostic, requires no GeoServer or GWC config change, no monkey-patching, fully unit-tested.

## Design

Trait shape mirrors the existing GetCapabilities path so authors who already understand how terriajs handles WMTS time can transfer their mental model 1:1:

```jsonc
{
  "type": "wmts",
  "url": "https://gwc.example.com/wmts",
  "layer": "methane:plumes",
  "time": {
    "values": [
      "2024-01-01T00:00:00Z",
      "2024-01-08T00:00:00Z",
      "2024-01-15T00:00:00Z"
    ],
    "defaultValue": "2024-01-15T00:00:00Z"
  }
}
```

Or with a regular interval:

```jsonc
"time": {
  "start": "2024-01-01T00:00:00Z",
  "stop":  "2024-12-31T00:00:00Z",
  "period": "P1D"
}
```

### Resolution order in `TimeOverrideStratum`

1. `time.values` (explicit list) — sorted ascending and used as-is.
2. `time.start` + `time.stop` + `time.period` — expanded via `createDiscreteTimesFromIsoSegments` (the same helper `GetCapabilitiesStratum` uses, so `maxRefreshIntervals` is honoured).
3. Both absent — stratum returns `undefined` and falls through to `GetCapabilitiesStratum`, **preserving existing behaviour** for every WMTS catalog item that already works.

`time.defaultValue` selects the initial `currentTime`; absent it, the most-recent discrete instant is selected (matches the GetCapabilities contract).

### Stratum priority

`TimeOverrideStratum` is registered via `StratumOrder.addLoadStratum` **after** `GetCapabilitiesStratum`, so it sits at higher priority. When the `time` trait is set, the override wins. When unset, `discreteTimes` and `currentTime` getters return `undefined` and the cascade falls through.

## Test plan

- [x] `yarn prettier-check` — clean
- [x] `yarn gulp lint` — clean
- [x] `yarn gulp build && yarn gulp test`
  - Baseline: **1544 specs / 30 failures**
  - This PR: **1548 specs / 30 failures** (4 new specs, all passing, 0 new failures)
- [x] 4 new specs cover the contract end-to-end:
  - `time.values` verbatim + ascending sort
  - `start`/`stop`/`period` expansion via `createDiscreteTimesFromIsoSegments`
  - `defaultValue` takes priority over the most-recent recency fallback
  - **Regression**: with no `time` trait, GetCapabilities still drives `discreteTimes` for the existing TERN fixture — locks in the "do no harm" guarantee

## Dual-branch porting plan

Once this lands on `wmts-time-dimension`:

1. Cherry-pick onto `wmts-time-bridge-8.11.1` (methaneview's current pin).
2. Cherry-pick onto `wmts-time-bridge-8.12.2` (the 8.12.x branch tracking I12 option B).
3. Bump methaneview-platform's terriajs git pin to whichever bridge branch wins.

Cherry-pick is held until this PR merges so we have one canonical source for the implementation rather than three drifting copies.

## Linked issues

- Closes nextavllc/terriajs#14
- Companion to upstream PR TerriaJS/terriajs#7835 (the WMTS+TIME imagery-provider work this builds on)
- Unblocks: methaneview-platform Path Z' replacement