### PR TITLE
feat(wmts): tileMatrixSetID trait — explicit matrix-set override

### DIFF
--- a/lib/Models/Catalog/Ows/WebMapTileServiceCatalogItem.ts
+++ b/lib/Models/Catalog/Ows/WebMapTileServiceCatalogItem.ts
@@ -1044,15 +1044,42 @@ class WebMapTileServiceCatalogItem extends MappableMixin(
     let tileHeight: number = 256;
     let tileMatrixSetLabels: string[] = [];
     let scheme: WebMercatorTilingScheme | GeographicTilingScheme;
-    for (let i = 0; i < tileMatrixSetLinks.length; i++) {
-      const tileMatrixSet = tileMatrixSetLinks[i].TileMatrixSet;
-      if (usableTileMatrixSets && usableTileMatrixSets[tileMatrixSet]) {
-        tileMatrixSetId = tileMatrixSet;
-        tileMatrixSetLabels = usableTileMatrixSets[tileMatrixSet].identifiers;
-        tileWidth = Number(usableTileMatrixSets[tileMatrixSet].tileWidth);
-        tileHeight = Number(usableTileMatrixSets[tileMatrixSet].tileHeight);
-        scheme = usableTileMatrixSets[tileMatrixSet].scheme;
-        break;
+
+    // If the catalog item declares an explicit `tileMatrixSetID`, prefer it.
+    // Required when GetCapabilities advertises multiple usable matrix sets
+    // (e.g. both EPSG:4326 and EPSG:900913) and the server's listing order
+    // doesn't match the viewer's tiling scheme. Falls through to the
+    // first-usable selection if the override doesn't match any link.
+    const requestedTileMatrixSetId = this.tileMatrixSetID;
+    if (requestedTileMatrixSetId) {
+      for (let i = 0; i < tileMatrixSetLinks.length; i++) {
+        const tileMatrixSet = tileMatrixSetLinks[i].TileMatrixSet;
+        if (
+          tileMatrixSet === requestedTileMatrixSetId &&
+          usableTileMatrixSets &&
+          usableTileMatrixSets[tileMatrixSet]
+        ) {
+          tileMatrixSetId = tileMatrixSet;
+          tileMatrixSetLabels = usableTileMatrixSets[tileMatrixSet].identifiers;
+          tileWidth = Number(usableTileMatrixSets[tileMatrixSet].tileWidth);
+          tileHeight = Number(usableTileMatrixSets[tileMatrixSet].tileHeight);
+          scheme = usableTileMatrixSets[tileMatrixSet].scheme;
+          break;
+        }
+      }
+    }
+
+    if (!tileMatrixSetId) {
+      for (let i = 0; i < tileMatrixSetLinks.length; i++) {
+        const tileMatrixSet = tileMatrixSetLinks[i].TileMatrixSet;
+        if (usableTileMatrixSets && usableTileMatrixSets[tileMatrixSet]) {
+          tileMatrixSetId = tileMatrixSet;
+          tileMatrixSetLabels = usableTileMatrixSets[tileMatrixSet].identifiers;
+          tileWidth = Number(usableTileMatrixSets[tileMatrixSet].tileWidth);
+          tileHeight = Number(usableTileMatrixSets[tileMatrixSet].tileHeight);
+          scheme = usableTileMatrixSets[tileMatrixSet].scheme;
+          break;
+        }
       }
     }
 

--- a/lib/Traits/TraitsClasses/WebMapTileServiceCatalogItemTraits.ts
+++ b/lib/Traits/TraitsClasses/WebMapTileServiceCatalogItemTraits.ts
@@ -197,6 +197,14 @@ export default class WebMapTileServiceCatalogItemTraits extends mixTraits(
   requestEncoding = "RESTful";
 
   @primitiveTrait({
+    type: "string",
+    name: "Tile Matrix Set ID",
+    description:
+      "Explicit `TileMatrixSet` identifier to use for this layer. When the WMTS service advertises multiple matrix sets in `GetCapabilities` (e.g. both `EPSG:4326` and `EPSG:900913`), the default first-usable selection picks the one listed first by the server, which may not match the viewer's tiling scheme (Web Mercator). Set this trait to force a specific matrix set. The value must match an `Identifier` listed under `TileMatrixSetLink` for the layer in GetCapabilities. When unset, the first matrix set that passes `usableTileMatrixSets` filtering is used (existing behaviour)."
+  })
+  tileMatrixSetID?: string;
+
+  @primitiveTrait({
     type: "number",
     name: "Maximum Refresh Intervals",
     description:

--- a/test/Models/Catalog/Ows/WebMapTileServiceCatalogItemSpec.ts
+++ b/test/Models/Catalog/Ows/WebMapTileServiceCatalogItemSpec.ts
@@ -162,6 +162,36 @@ describe("WebMapTileServiceCatalogItem", function () {
     expect(wmts.tileMatrixSet!.tileHeight).toEqual(256);
   });
 
+  it("honours explicit tileMatrixSetID matching an advertised link", async function () {
+    runInAction(() => {
+      wmts.setTrait("definition", "url", "test/WMTS/with_tilematrix.xml");
+      wmts.setTrait("definition", "layer", "Some_Layer1");
+      wmts.setTrait(
+        "definition",
+        "tileMatrixSetID",
+        "GoogleMapsCompatible_Level9"
+      );
+    });
+
+    await wmts.loadMapItems();
+    expect(wmts.tileMatrixSet).toBeDefined();
+    expect(wmts.tileMatrixSet!.id).toEqual("GoogleMapsCompatible_Level9");
+  });
+
+  it("falls through to first-usable when tileMatrixSetID does not match any link", async function () {
+    runInAction(() => {
+      wmts.setTrait("definition", "url", "test/WMTS/with_tilematrix.xml");
+      wmts.setTrait("definition", "layer", "Some_Layer1");
+      wmts.setTrait("definition", "tileMatrixSetID", "EPSG:4326");
+    });
+
+    await wmts.loadMapItems();
+    // The fixture only advertises GoogleMapsCompatible_Level9 for Some_Layer1.
+    // Override doesn't match, so the existing first-usable behaviour wins.
+    expect(wmts.tileMatrixSet).toBeDefined();
+    expect(wmts.tileMatrixSet!.id).toEqual("GoogleMapsCompatible_Level9");
+  });
+
   xit("non existing tile matrix set", async function () {
     runInAction(() => {
       wmts.setTrait("definition", "url", "test/WMTS/with_tilematrix.xml");


### PR DESCRIPTION
## Summary

When a WMTS layer's `GetCapabilities` advertises multiple `TileMatrixSetLink` entries (e.g. both `EPSG:4326` and `EPSG:900913`, common for GeoServer GWC layers), the existing picker iterates in document order and takes the first link that passes `usableTileMatrixSets` filtering. If the server lists the geographic matrix set first and the viewer expects Web Mercator tiling, the selection mismatches the engine's tiling scheme and **the imagery provider never emits a single GetTile request** — the layer loads metadata, fetches GetCapabilities, then sits silently.

Verified-in-the-wild symptom (on a NextAV-internal GWC layer):
- 4 metadata-only requests in 20s (catalog init x2, GetCapabilities, GetLegendGraphic).
- **0 GetTile requests.**
- curl probe with explicit `&TileMatrixSet=EPSG:900913&...` returns 200 image/png — endpoint is healthy; only the auto-pick is wrong.

## Fix

Add an optional `tileMatrixSetID` string trait. When set, the matrix-set getter prefers the matching `TileMatrixSetLink` (if it passes usability filtering) and falls through to the existing first-usable behaviour otherwise. When unset, behaviour is identical to before — zero backward-compat impact.

## Tests

- `honours explicit tileMatrixSetID matching an advertised link`
- `falls through to first-usable when tileMatrixSetID does not match any link`

## Usage

```json
{
  "id": "ch4-plume",
  "type": "wmts",
  "url": "/geoserver/gwc/service/wmts",
  "layer": "nextview:ch4_plume_mosaic",
  "tileMatrixSetID": "EPSG:900913"
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)